### PR TITLE
feat :: [#65] message history api

### DIFF
--- a/src/main/kotlin/dsm/wemeet/domain/chat/service/QueryChatService.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/chat/service/QueryChatService.kt
@@ -1,8 +1,11 @@
 package dsm.wemeet.domain.chat.service
 
 import dsm.wemeet.domain.chat.repository.model.Chat
+import java.util.UUID
 
 interface QueryChatService {
 
     fun queryChatByUser(user1: String, user2: String): Chat?
+
+    fun queryChatById(id: UUID): Chat
 }

--- a/src/main/kotlin/dsm/wemeet/domain/chat/service/impl/QueryChatServiceImpl.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/chat/service/impl/QueryChatServiceImpl.kt
@@ -1,8 +1,11 @@
 package dsm.wemeet.domain.chat.service.impl
 
+import dsm.wemeet.domain.chat.exception.ChatNotFoundException
 import dsm.wemeet.domain.chat.repository.ChatJpaRepository
 import dsm.wemeet.domain.chat.service.QueryChatService
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 @Service
 class QueryChatServiceImpl(
@@ -11,4 +14,7 @@ class QueryChatServiceImpl(
 
     override fun queryChatByUser(user1: String, user2: String) =
         chatJpaRepository.findChatByUsers(user1, user2)
+
+    override fun queryChatById(id: UUID) =
+        chatJpaRepository.findByIdOrNull(id) ?: throw ChatNotFoundException
 }

--- a/src/main/kotlin/dsm/wemeet/domain/message/presentation/MessageController.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/presentation/MessageController.kt
@@ -1,0 +1,19 @@
+package dsm.wemeet.domain.message.presentation
+
+import dsm.wemeet.domain.message.usecase.QueryMessageUseCase
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/message")
+class MessageController(
+    private val queryMessageUseCase: QueryMessageUseCase
+) {
+
+    @GetMapping("/{chat-id}")
+    fun getMessage(@PathVariable("chat-id") chatId: UUID) =
+        queryMessageUseCase.execute(chatId)
+}

--- a/src/main/kotlin/dsm/wemeet/domain/message/presentation/dto/response/MessageResponse.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/presentation/dto/response/MessageResponse.kt
@@ -1,7 +1,9 @@
 package dsm.wemeet.domain.message.presentation.dto.response
 
+import java.time.LocalDateTime
+
 data class MessageResponse(
     val sender: String,
     val content: String,
-    val timestamp: Long
+    val sendAt: LocalDateTime
 )

--- a/src/main/kotlin/dsm/wemeet/domain/message/repository/MessageJpaRepository.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/repository/MessageJpaRepository.kt
@@ -4,4 +4,6 @@ import dsm.wemeet.domain.message.repository.model.Message
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
-interface MessageJpaRepository : JpaRepository<Message, UUID>
+interface MessageJpaRepository : JpaRepository<Message, UUID> {
+    fun findAllByChatId(chatId: UUID): List<Message>?
+}

--- a/src/main/kotlin/dsm/wemeet/domain/message/repository/MessageJpaRepository.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/repository/MessageJpaRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
 interface MessageJpaRepository : JpaRepository<Message, UUID> {
-    fun findAllByChatId(chatId: UUID): List<Message>?
+    fun findAllByChatId(chatId: UUID): List<Message>
 }

--- a/src/main/kotlin/dsm/wemeet/domain/message/service/QueryMessageService.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/service/QueryMessageService.kt
@@ -4,5 +4,5 @@ import dsm.wemeet.domain.message.repository.model.Message
 import java.util.UUID
 
 interface QueryMessageService {
-    fun queryMessageListByChat(chatId: UUID): List<Message>?
+    fun queryMessageListByChat(chatId: UUID): List<Message>
 }

--- a/src/main/kotlin/dsm/wemeet/domain/message/service/QueryMessageService.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/service/QueryMessageService.kt
@@ -1,0 +1,8 @@
+package dsm.wemeet.domain.message.service
+
+import dsm.wemeet.domain.message.repository.model.Message
+import java.util.UUID
+
+interface QueryMessageService {
+    fun queryMessageListByChat(chatId: UUID): List<Message>?
+}

--- a/src/main/kotlin/dsm/wemeet/domain/message/service/impl/QueryMessageServiceImpl.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/service/impl/QueryMessageServiceImpl.kt
@@ -1,0 +1,15 @@
+package dsm.wemeet.domain.message.service.impl
+
+import dsm.wemeet.domain.message.repository.MessageJpaRepository
+import dsm.wemeet.domain.message.service.QueryMessageService
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class QueryMessageServiceImpl(
+    private val messageJpaRepository: MessageJpaRepository
+) : QueryMessageService {
+
+    override fun queryMessageListByChat(chatId: UUID) =
+        messageJpaRepository.findAllByChatId(chatId)
+}

--- a/src/main/kotlin/dsm/wemeet/domain/message/usecase/QueryMessageUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/usecase/QueryMessageUseCase.kt
@@ -1,0 +1,26 @@
+package dsm.wemeet.domain.message.usecase
+
+import dsm.wemeet.domain.message.presentation.dto.response.MessageResponse
+import dsm.wemeet.domain.message.service.QueryMessageService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Transactional(readOnly = true)
+@Service
+class QueryMessageUseCase(
+    private val queryMessageService: QueryMessageService
+) {
+
+    fun execute(chatId: UUID): List<MessageResponse?> {
+        val messages = queryMessageService.queryMessageListByChat(chatId)
+
+        return messages?.map {
+            MessageResponse(
+                sender = it.sender.email,
+                content = it.content,
+                sendAt = it.sendAt
+            )
+        } ?: emptyList()
+    }
+}

--- a/src/main/kotlin/dsm/wemeet/domain/message/usecase/QueryMessageUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/usecase/QueryMessageUseCase.kt
@@ -17,7 +17,6 @@ class QueryMessageUseCase(
     fun execute(chatId: UUID): List<MessageResponse> {
         val chat = queryChatService.queryChatById(chatId)
         return queryMessageService.queryMessageListByChat(chat.id!!)
-            .orEmpty()
             .map {
                 MessageResponse(
                     sender = it.sender.email,

--- a/src/main/kotlin/dsm/wemeet/domain/message/usecase/QueryMessageUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/usecase/QueryMessageUseCase.kt
@@ -1,5 +1,6 @@
 package dsm.wemeet.domain.message.usecase
 
+import dsm.wemeet.domain.chat.service.QueryChatService
 import dsm.wemeet.domain.message.presentation.dto.response.MessageResponse
 import dsm.wemeet.domain.message.service.QueryMessageService
 import org.springframework.stereotype.Service
@@ -9,18 +10,20 @@ import java.util.UUID
 @Transactional(readOnly = true)
 @Service
 class QueryMessageUseCase(
-    private val queryMessageService: QueryMessageService
+    private val queryMessageService: QueryMessageService,
+    private val queryChatService: QueryChatService
 ) {
 
-    fun execute(chatId: UUID): List<MessageResponse?> {
-        val messages = queryMessageService.queryMessageListByChat(chatId)
-
-        return messages?.map {
-            MessageResponse(
-                sender = it.sender.email,
-                content = it.content,
-                sendAt = it.sendAt
-            )
-        } ?: emptyList()
+    fun execute(chatId: UUID): List<MessageResponse> {
+        val chat = queryChatService.queryChatById(chatId)
+        return queryMessageService.queryMessageListByChat(chat.id!!)
+            .orEmpty()
+            .map {
+                MessageResponse(
+                    sender = it.sender.email,
+                    content = it.content,
+                    sendAt = it.sendAt
+                )
+            }.sortedBy { it.sendAt }
     }
 }

--- a/src/main/kotlin/dsm/wemeet/domain/message/usecase/SendMessageUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/usecase/SendMessageUseCase.kt
@@ -9,6 +9,7 @@ import dsm.wemeet.domain.message.service.SaveMessageService
 import dsm.wemeet.domain.user.service.QueryUserService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 @Transactional
@@ -29,6 +30,6 @@ class SendMessageUseCase(
         val message = Message(chat = chat, sender = sender, content = content)
         saveMessageService.save(message)
 
-        return MessageResponse(sender.email, content, System.currentTimeMillis())
+        return MessageResponse(sender.email, content, LocalDateTime.now())
     }
 }

--- a/src/main/kotlin/dsm/wemeet/domain/message/usecase/SendMessageUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/message/usecase/SendMessageUseCase.kt
@@ -21,15 +21,15 @@ class SendMessageUseCase(
 ) {
 
     fun sendMessage(sender: String, receiver: String, content: String): MessageResponse {
-        val sender = queryUserService.queryUserByEmail(sender)
-        val receiver = queryUserService.queryUserByEmail(receiver)
+        val sendUser = queryUserService.queryUserByEmail(sender)
+        val receiveUser = queryUserService.queryUserByEmail(receiver)
 
-        val chat = queryChatService.queryChatByUser(sender.email, receiver.email)
-            ?: saveChatService.save(Chat(user1 = sender, user2 = receiver))
+        val chat = queryChatService.queryChatByUser(sendUser.email, receiveUser.email)
+            ?: saveChatService.save(Chat(user1 = sendUser, user2 = receiveUser))
 
-        val message = Message(chat = chat, sender = sender, content = content)
+        val message = Message(chat = chat, sender = sendUser, content = content)
         saveMessageService.save(message)
 
-        return MessageResponse(sender.email, content, LocalDateTime.now())
+        return MessageResponse(sendUser.email, content, LocalDateTime.now())
     }
 }

--- a/src/main/kotlin/dsm/wemeet/domain/room/usecase/CreateRoomUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/room/usecase/CreateRoomUseCase.kt
@@ -29,7 +29,7 @@ class CreateRoomUseCase(
             )
         )
 
-        val member = commandRoomService.saveMember(
+        commandRoomService.saveMember(
             Member(
                 room = room,
                 user = currentUser

--- a/src/main/kotlin/dsm/wemeet/domain/room/usecase/JoinRoomUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/room/usecase/JoinRoomUseCase.kt
@@ -24,7 +24,7 @@ class JoinRoomUseCase(
 
         checkRoomService.validateUserNotAlreadyInRoom(currentUser, currentRoom)
 
-        val member = commandRoomService.saveMember(
+        commandRoomService.saveMember(
             Member(
                 room = currentRoom,
                 user = currentUser

--- a/src/main/kotlin/dsm/wemeet/global/socket/ChatWebSocketHandler.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/ChatWebSocketHandler.kt
@@ -37,7 +37,7 @@ class ChatWebSocketHandler(
         val responseJson = JSONObject()
             .put("sender", result.sender)
             .put("content", result.content)
-            .put("timestamp", result.timestamp)
+            .put("sendAt", result.sendAt)
 
         receiverSession?.takeIf { it.isOpen }?.sendMessage(TextMessage(responseJson.toString()))
     }


### PR DESCRIPTION
close #65 
<img width="577" alt="스크린샷 2025-04-15 14 35 18" src="https://github.com/user-attachments/assets/2ceb7799-87f0-4506-a5de-71d07adc538e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 채팅 ID로 메시지 목록을 조회할 수 있는 REST API 엔드포인트가 추가되었습니다.
    - 메시지 목록을 조회하는 서비스 및 관련 유스케이스가 도입되었습니다.
    - 채팅 ID로 채팅 정보를 조회하는 기능이 추가되었습니다.

- **개선 사항**
    - 메시지 응답의 타임스탬프 필드명이 sendAt으로 변경되고, 타입이 LocalDateTime으로 변경되었습니다.
    - WebSocket 메시지 응답의 타임스탬프 키가 sendAt으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->