### PR TITLE
fix :: [#77] 끝나지않는 cors 해결

### DIFF
--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -45,9 +45,10 @@ class SecurityConfig(
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
 
-        // TODO 프론트 배포되면 URL 붙이기
-        // configuration.addAllowedOriginPattern("https://")
-        configuration.addAllowedOriginPattern("*")
+        configuration.allowedOrigins = listOf (
+            "http://localhost:3000",
+            "https://we-meet-fe.vercel.app"
+        )
         configuration.addAllowedHeader("*")
         configuration.addAllowedMethod("*")
         configuration.allowCredentials = true

--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -45,7 +45,7 @@ class SecurityConfig(
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
 
-        configuration.allowedOrigins = listOf (
+        configuration.allowedOrigins = listOf(
             "http://localhost:3000",
             "https://we-meet-fe.vercel.app"
         )


### PR DESCRIPTION
rosolve #77 
젠장 또 cors야

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - CORS 설정에서 허용되는 오리진을 와일드카드(*)에서 특정 도메인(`http://localhost:3000`, `https://we-meet-fe.vercel.app`)으로 제한하여 보안을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->