### PR TITLE
fix :: [#79] cors 찐 막 해결

### DIFF
--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -47,7 +47,8 @@ class SecurityConfig(
 
         configuration.allowedOrigins = listOf(
             "http://localhost:3000",
-            "https://we-meet-fe.vercel.app"
+            "http://127.0.0.1:3000",
+            "https://we-meet-fe.vercel.app",
         )
         configuration.addAllowedHeader("*")
         configuration.addAllowedMethod("*")

--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -11,9 +11,6 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.web.cors.CorsConfiguration
-import org.springframework.web.cors.CorsConfigurationSource
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 class SecurityConfig(
@@ -39,5 +36,5 @@ class SecurityConfig(
     }
 
     @Bean
-    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()    
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 }

--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -39,23 +39,5 @@ class SecurityConfig(
     }
 
     @Bean
-    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
-
-    @Bean
-    fun corsConfigurationSource(): CorsConfigurationSource {
-        val configuration = CorsConfiguration()
-
-        configuration.allowedOrigins = listOf(
-            "http://localhost:3000",
-            "http://127.0.0.1:3000",
-            "https://we-meet-fe.vercel.app"
-        )
-        configuration.addAllowedHeader("*")
-        configuration.addAllowedMethod("*")
-        configuration.allowCredentials = true
-
-        val source = UrlBasedCorsConfigurationSource()
-        source.registerCorsConfiguration("/**", configuration)
-        return source
-    }
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()    
 }

--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -48,7 +48,7 @@ class SecurityConfig(
         configuration.allowedOrigins = listOf(
             "http://localhost:3000",
             "http://127.0.0.1:3000",
-            "https://we-meet-fe.vercel.app",
+            "https://we-meet-fe.vercel.app"
         )
         configuration.addAllowedHeader("*")
         configuration.addAllowedMethod("*")


### PR DESCRIPTION
resolve #79 
정답은 xquare 문제인 것 같고요
서버 선에서 해줄 수 있는건 localhost를 열어주는 것 밖에 없네요 에휴
<수정> 아몰라 이거 안되면 다 죽어보자

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - CORS 허용 origin에 "http://127.0.0.1:3000"이 추가되어 로컬 환경에서의 접근성이 개선되었습니다.
- **기타**
  - 기존에 명시적으로 설정된 CORS 구성이 제거되어 보안 설정이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->