### PR TITLE
refactor :: [#81] 시큐리티 엔드포인트 설정 + cors 부활;

### DIFF
--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -43,7 +43,6 @@ class SecurityConfig(
                 .requestMatchers(HttpMethod.POST, "/mail").permitAll()
                 .requestMatchers(HttpMethod.POST, "/mail/check").permitAll()
                 .requestMatchers(HttpMethod.GET, "/friends").authenticated()
-                .requestMatchers(HttpMethod.GET, "/friends/search").authenticated()
                 .requestMatchers(HttpMethod.POST, "/friends/{friend-id}").authenticated()
                 .requestMatchers(HttpMethod.POST, "/friends/request/{friend-id}").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/friends/request/{friend-id}").authenticated()

--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -6,7 +6,6 @@ import dsm.wemeet.global.jwt.JwtProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
-import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -41,10 +40,8 @@ class SecurityConfig(
                 .requestMatchers(HttpMethod.GET, "/user/exist/{account-id}").permitAll()
                 .requestMatchers(HttpMethod.GET, "/user/accountId").authenticated()
                 .requestMatchers(HttpMethod.GET, "/user").authenticated()
-
                 .requestMatchers(HttpMethod.POST, "/mail").permitAll()
                 .requestMatchers(HttpMethod.POST, "/mail/check").permitAll()
-
                 .requestMatchers(HttpMethod.GET, "/friends").authenticated()
                 .requestMatchers(HttpMethod.GET, "/friends/search").authenticated()
                 .requestMatchers(HttpMethod.POST, "/friends/{friend-id}").authenticated()
@@ -52,17 +49,14 @@ class SecurityConfig(
                 .requestMatchers(HttpMethod.DELETE, "/friends/request/{friend-id}").authenticated()
                 .requestMatchers(HttpMethod.GET, "/friends/my").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/friends/{friend-id}").authenticated()
-
                 .requestMatchers(HttpMethod.POST, "/rooms").authenticated()
                 .requestMatchers(HttpMethod.POST, "/rooms/{room-id}").authenticated()
                 .requestMatchers(HttpMethod.GET, "/rooms").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/rooms/{room-id}").authenticated()
                 .requestMatchers(HttpMethod.POST, "/rooms/password/{room-id}").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/rooms/{room-id}/members/{account-id}").authenticated()
-
                 .requestMatchers(HttpMethod.GET, "/chat/list").authenticated()
                 .requestMatchers(HttpMethod.GET, "/message/{chat-id}").authenticated()
-
                 .anyRequest().denyAll()
         }
             .apply(FilterConfig(jwtProvider, objectMapper))

--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -12,6 +12,9 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 class SecurityConfig(
@@ -24,7 +27,7 @@ class SecurityConfig(
         http
             .csrf { it.disable() }
             .formLogin { it.disable() }
-            .cors(Customizer.withDefaults())
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
 
         http.authorizeHttpRequests { authorize ->
@@ -69,4 +72,22 @@ class SecurityConfig(
 
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+
+        configuration.allowedOrigins = listOf(
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "https://we-meet-fe.vercel.app"
+        )
+        configuration.addAllowedHeader("*")
+        configuration.addAllowedMethod("*")
+        configuration.allowCredentials = true
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
 }

--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -5,6 +5,7 @@ import dsm.wemeet.global.config.filter.FilterConfig
 import dsm.wemeet.global.jwt.JwtProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -28,7 +29,38 @@ class SecurityConfig(
 
         http.authorizeHttpRequests { authorize ->
             authorize
-                .anyRequest().permitAll()
+                .requestMatchers(HttpMethod.POST, "/user/signUp").permitAll()
+                .requestMatchers(HttpMethod.POST, "/user/signIn").permitAll()
+                .requestMatchers(HttpMethod.POST, "/user/refresh").permitAll()
+                .requestMatchers(HttpMethod.PATCH, "/user/profile").authenticated()
+                .requestMatchers(HttpMethod.PATCH, "/user/update").authenticated()
+                .requestMatchers(HttpMethod.GET, "/user/myPage").authenticated()
+                .requestMatchers(HttpMethod.GET, "/user/exist/{account-id}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/user/accountId").authenticated()
+                .requestMatchers(HttpMethod.GET, "/user").authenticated()
+
+                .requestMatchers(HttpMethod.POST, "/mail").permitAll()
+                .requestMatchers(HttpMethod.POST, "/mail/check").permitAll()
+
+                .requestMatchers(HttpMethod.GET, "/friends").authenticated()
+                .requestMatchers(HttpMethod.GET, "/friends/search").authenticated()
+                .requestMatchers(HttpMethod.POST, "/friends/{friend-id}").authenticated()
+                .requestMatchers(HttpMethod.POST, "/friends/request/{friend-id}").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/friends/request/{friend-id}").authenticated()
+                .requestMatchers(HttpMethod.GET, "/friends/my").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/friends/{friend-id}").authenticated()
+
+                .requestMatchers(HttpMethod.POST, "/rooms").authenticated()
+                .requestMatchers(HttpMethod.POST, "/rooms/{room-id}").authenticated()
+                .requestMatchers(HttpMethod.GET, "/rooms").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/rooms/{room-id}").authenticated()
+                .requestMatchers(HttpMethod.POST, "/rooms/password/{room-id}").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/rooms/{room-id}/members/{account-id}").authenticated()
+
+                .requestMatchers(HttpMethod.GET, "/chat/list").authenticated()
+                .requestMatchers(HttpMethod.GET, "/message/{chat-id}").authenticated()
+
+                .anyRequest().denyAll()
         }
             .apply(FilterConfig(jwtProvider, objectMapper))
 


### PR DESCRIPTION
resolve #81 
cors 제대로 다시 적용시켜봄 + 엔드포인트 설정 해둠

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 특정 프론트엔드 도메인 및 로컬호스트(3000 포트)에서의 접근을 허용하는 CORS 정책이 적용되었습니다.
- **버그 수정**
    - 인증이 필요 없는 엔드포인트와 인증이 필요한 엔드포인트가 명확하게 구분되어 보안이 강화되었습니다.
    - 모든 미지정 요청에 대해 접근이 차단됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->