### PR TITLE
refactor :: [#86] 시그널링 join, leave, exist 메시지 accountId 추가

### DIFF
--- a/src/main/kotlin/dsm/wemeet/domain/room/exception/RoomIsFullException.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/room/exception/RoomIsFullException.kt
@@ -1,0 +1,8 @@
+package dsm.wemeet.domain.room.exception
+
+import WeMeetException
+import dsm.wemeet.global.error.exception.ErrorCode
+
+object RoomIsFullException : WeMeetException(
+    ErrorCode.ROOM_IS_FULL
+)

--- a/src/main/kotlin/dsm/wemeet/domain/room/repository/MemberJpaRepository.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/room/repository/MemberJpaRepository.kt
@@ -13,4 +13,6 @@ interface MemberJpaRepository : JpaRepository<Member, UUID> {
     fun findAllByRoomIdOrderByJoinedAt(roomId: UUID): List<Member>
 
     fun existsMemberByUserAndRoom(user: User, room: Room): Boolean
+
+    fun countMemberByRoomId(roomId: UUID): Long
 }

--- a/src/main/kotlin/dsm/wemeet/domain/room/service/CheckRoomService.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/room/service/CheckRoomService.kt
@@ -6,4 +6,6 @@ import dsm.wemeet.domain.user.repository.model.User
 interface CheckRoomService {
 
     fun validateUserNotAlreadyInRoom(user: User, room: Room)
+
+    fun validateRoomIsNotFull(room: Room)
 }

--- a/src/main/kotlin/dsm/wemeet/domain/room/service/impl/CheckRoomServiceImpl.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/room/service/impl/CheckRoomServiceImpl.kt
@@ -1,6 +1,7 @@
 package dsm.wemeet.domain.room.service.impl
 
 import dsm.wemeet.domain.room.exception.AlreadyJoinedRoomException
+import dsm.wemeet.domain.room.exception.RoomIsFullException
 import dsm.wemeet.domain.room.repository.MemberJpaRepository
 import dsm.wemeet.domain.room.repository.model.Room
 import dsm.wemeet.domain.room.service.CheckRoomService
@@ -15,6 +16,12 @@ class CheckRoomServiceImpl(
     override fun validateUserNotAlreadyInRoom(user: User, room: Room) {
         if (memberJpaRepository.existsMemberByUserAndRoom(user, room)) {
             throw AlreadyJoinedRoomException
+        }
+    }
+
+    override fun validateRoomIsNotFull(room: Room) {
+        if (memberJpaRepository.countMemberByRoomId(room.id!!) >= room.maxMember) {
+            throw RoomIsFullException
         }
     }
 }

--- a/src/main/kotlin/dsm/wemeet/domain/room/usecase/JoinRoomUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/room/usecase/JoinRoomUseCase.kt
@@ -23,6 +23,7 @@ class JoinRoomUseCase(
         val currentUser = queryUserService.getCurrentUser()
 
         checkRoomService.validateUserNotAlreadyInRoom(currentUser, currentRoom)
+        checkRoomService.validateRoomIsNotFull(currentRoom)
 
         commandRoomService.saveMember(
             Member(

--- a/src/main/kotlin/dsm/wemeet/global/config/socket/SocketConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/socket/SocketConfig.kt
@@ -1,5 +1,6 @@
 package dsm.wemeet.global.config.socket
 
+import dsm.wemeet.domain.user.service.QueryUserService
 import dsm.wemeet.global.jwt.JwtProvider
 import dsm.wemeet.global.socket.domain.ChatWebSocketHandler
 import dsm.wemeet.global.socket.domain.RoomWebSocketHandler
@@ -16,7 +17,8 @@ import org.springframework.web.util.UriTemplate
 class SocketConfig(
     private val chatWebSocketHandler: ChatWebSocketHandler,
     private val roomWebSocketHandler: RoomWebSocketHandler,
-    private val jwtProvider: JwtProvider
+    private val jwtProvider: JwtProvider,
+    private val queryUserService: QueryUserService
 ) : WebSocketConfigurer {
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
         registry.addHandler(chatWebSocketHandler, "/ws/chat")
@@ -24,7 +26,7 @@ class SocketConfig(
         registry.addHandler(roomWebSocketHandler, "/ws/rooms/*")
             .setAllowedOrigins("*")
             .addInterceptors(
-                AuthorizeInterceptor(jwtProvider),
+                AuthorizeInterceptor(jwtProvider, queryUserService),
                 PathParsingInterceptor(UriTemplate("/ws/rooms/{roomId}"))
             )
     }

--- a/src/main/kotlin/dsm/wemeet/global/config/socket/SocketConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/socket/SocketConfig.kt
@@ -2,6 +2,7 @@ package dsm.wemeet.global.config.socket
 
 import dsm.wemeet.domain.user.service.QueryUserService
 import dsm.wemeet.global.jwt.JwtProvider
+import dsm.wemeet.global.s3.S3Util
 import dsm.wemeet.global.socket.domain.ChatWebSocketHandler
 import dsm.wemeet.global.socket.domain.RoomWebSocketHandler
 import dsm.wemeet.global.socket.intercept.AuthorizeInterceptor
@@ -18,7 +19,8 @@ class SocketConfig(
     private val chatWebSocketHandler: ChatWebSocketHandler,
     private val roomWebSocketHandler: RoomWebSocketHandler,
     private val jwtProvider: JwtProvider,
-    private val queryUserService: QueryUserService
+    private val queryUserService: QueryUserService,
+    private val s3Util: S3Util
 ) : WebSocketConfigurer {
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
         registry.addHandler(chatWebSocketHandler, "/ws/chat")
@@ -26,7 +28,7 @@ class SocketConfig(
         registry.addHandler(roomWebSocketHandler, "/ws/rooms/*")
             .setAllowedOrigins("*")
             .addInterceptors(
-                AuthorizeInterceptor(jwtProvider, queryUserService),
+                AuthorizeInterceptor(jwtProvider, queryUserService, s3Util),
                 PathParsingInterceptor(UriTemplate("/ws/rooms/{roomId}"))
             )
     }

--- a/src/main/kotlin/dsm/wemeet/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/dsm/wemeet/global/error/exception/ErrorCode.kt
@@ -30,6 +30,7 @@ enum class ErrorCode(
     USER_ALREADY_EXISTS(409, "User Already Exists"),
     FRIEND_ALREADY_EXISTS(409, "Friend Already Exists"),
     ALREADY_JOINED_ROOM(409, "Already Joined Room"),
+    ROOM_IS_FULL(409, "Room Is Full"),
 
     INTERNAL_MAIL_SERVER_ERROR(500, "Internal Mail Server Error"),
     FILE_UPLOAD_ERROR(500, "File Upload Error"),

--- a/src/main/kotlin/dsm/wemeet/global/socket/domain/RoomWebSocketHandler.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/domain/RoomWebSocketHandler.kt
@@ -28,7 +28,6 @@ class RoomWebSocketHandler(
     private val roomPeers: ConcurrentMap<UUID, CopyOnWriteArrayList<WebSocketSession>> = ConcurrentHashMap()
 
     override fun afterConnectionEstablished(session: WebSocketSession) {
-        val userEmail = getUserEmail(session)
         val roomId = getRoomId(session)
         val peers = roomPeers.computeIfAbsent(roomId) { CopyOnWriteArrayList() }
 
@@ -94,7 +93,6 @@ class RoomWebSocketHandler(
     }
 
     private fun leaveAndCleanUp(session: WebSocketSession) {
-        val userEmail = getUserEmail(session)
         val roomId = getRoomId(session)
 
         roomPeers[roomId]?.let { list ->

--- a/src/main/kotlin/dsm/wemeet/global/socket/domain/RoomWebSocketHandler.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/domain/RoomWebSocketHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
+import java.util.Optional
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
@@ -123,6 +124,9 @@ class RoomWebSocketHandler(
     private fun getAccountId(session: WebSocketSession): String =
         session.attributes["accountId"]!!.toString()
 
+    private fun getProfile(session: WebSocketSession): String? =
+        (session.attributes["profile"]!! as Optional<String>).orElse(null)
+
     private fun createMsg(type: String, payload: String): JSONObject =
         JSONObject()
             .put("type", type)
@@ -130,6 +134,7 @@ class RoomWebSocketHandler(
 
     private fun WebSocketSession.toPeer() = Peer(
         getUserEmail(this),
-        getAccountId(this)
+        getAccountId(this),
+        getProfile(this)
     )
 }

--- a/src/main/kotlin/dsm/wemeet/global/socket/intercept/AuthorizeInterceptor.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/intercept/AuthorizeInterceptor.kt
@@ -2,6 +2,7 @@ package dsm.wemeet.global.socket.intercept
 
 import dsm.wemeet.domain.user.service.QueryUserService
 import dsm.wemeet.global.jwt.JwtProvider
+import dsm.wemeet.global.s3.S3Util
 import org.springframework.http.HttpStatus
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
@@ -9,10 +10,12 @@ import org.springframework.web.socket.WebSocketHandler
 import org.springframework.web.socket.server.HandshakeInterceptor
 import org.springframework.web.util.UriComponentsBuilder
 import java.lang.Exception
+import java.util.Optional
 
 class AuthorizeInterceptor(
     private val jwtProvider: JwtProvider,
-    private val queryUserService: QueryUserService
+    private val queryUserService: QueryUserService,
+    private val s3Util: S3Util
 ) : HandshakeInterceptor {
     override fun beforeHandshake(
         request: ServerHttpRequest,
@@ -29,8 +32,11 @@ class AuthorizeInterceptor(
 
         return try {
             val mail = jwtProvider.getJws(token).body.subject
-            attributes["email"] = mail
-            attributes["accountId"] = queryUserService.queryUserByEmail(mail).accountId
+            val currentUser = queryUserService.queryUserByEmail(mail)
+
+            attributes["email"] = currentUser.email
+            attributes["accountId"] = currentUser.accountId
+            attributes["profile"] = Optional.ofNullable(currentUser.profile?.let { s3Util.generateUrl(it) })
             true
         } catch (e: Exception) {
             response.setStatusCode(HttpStatus.UNAUTHORIZED)

--- a/src/main/kotlin/dsm/wemeet/global/socket/intercept/AuthorizeInterceptor.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/intercept/AuthorizeInterceptor.kt
@@ -1,5 +1,6 @@
 package dsm.wemeet.global.socket.intercept
 
+import dsm.wemeet.domain.user.service.QueryUserService
 import dsm.wemeet.global.jwt.JwtProvider
 import org.springframework.http.HttpStatus
 import org.springframework.http.server.ServerHttpRequest
@@ -10,7 +11,8 @@ import org.springframework.web.util.UriComponentsBuilder
 import java.lang.Exception
 
 class AuthorizeInterceptor(
-    private val jwtProvider: JwtProvider
+    private val jwtProvider: JwtProvider,
+    private val queryUserService: QueryUserService
 ) : HandshakeInterceptor {
     override fun beforeHandshake(
         request: ServerHttpRequest,
@@ -26,7 +28,9 @@ class AuthorizeInterceptor(
         }
 
         return try {
-            attributes["email"] = jwtProvider.getJws(token).body.subject
+            val mail = attributes["email"] as String
+            attributes["email"] = mail
+            attributes["accountId"] = queryUserService.queryUserByEmail(mail).accountId
             true
         } catch (e: Exception) {
             response.setStatusCode(HttpStatus.UNAUTHORIZED)

--- a/src/main/kotlin/dsm/wemeet/global/socket/intercept/AuthorizeInterceptor.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/intercept/AuthorizeInterceptor.kt
@@ -28,7 +28,7 @@ class AuthorizeInterceptor(
         }
 
         return try {
-            val mail = attributes["email"] as String
+            val mail = jwtProvider.getJws(token).body.subject
             attributes["email"] = mail
             attributes["accountId"] = queryUserService.queryUserByEmail(mail).accountId
             true

--- a/src/main/kotlin/dsm/wemeet/global/socket/vo/Peer.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/vo/Peer.kt
@@ -2,5 +2,6 @@ package dsm.wemeet.global.socket.vo
 
 data class Peer(
     val mail: String,
-    val accountId: String
+    val accountId: String,
+    val profile: String?
 )

--- a/src/main/kotlin/dsm/wemeet/global/socket/vo/Peer.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/vo/Peer.kt
@@ -1,0 +1,6 @@
+package dsm.wemeet.global.socket.vo
+
+data class Peer(
+    val mail: String,
+    val accountId: String
+)


### PR DESCRIPTION
resolve #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - WebSocket 메시지에서 사용자 정보를 이메일, 계정 ID, 프로필을 포함하는 객체로 개선하여 제공하도록 변경되었습니다.
  - 사용자 인증 시 계정 ID와 프로필 URL을 함께 조회하여 세션에 저장하는 기능이 추가되었습니다.
  - 방 입장 시 방 인원 수를 확인하여 방이 가득 찬 경우 입장이 제한되도록 검증 기능이 추가되었습니다.
  - 방이 가득 찼을 때 발생하는 전용 예외와 이에 대응하는 오류 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->