### PR TITLE
feat/94 friend request list api

### DIFF
--- a/src/main/kotlin/dsm/wemeet/domain/friend/presentation/FriendController.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/presentation/FriendController.kt
@@ -1,8 +1,10 @@
 package dsm.wemeet.domain.friend.presentation
 
+import dsm.wemeet.domain.friend.presentation.dto.response.FriendRequestListResponse
 import dsm.wemeet.domain.friend.presentation.dto.response.UserListResponse
 import dsm.wemeet.domain.friend.usecase.HandleFriendRequestUseCase
 import dsm.wemeet.domain.friend.usecase.QueryMyFriendListUseCase
+import dsm.wemeet.domain.friend.usecase.QueryMyFriendRequestListUseCase
 import dsm.wemeet.domain.friend.usecase.QueryUserListUseCase
 import dsm.wemeet.domain.friend.usecase.RequestFriendUseCase
 import jakarta.validation.constraints.Min
@@ -23,7 +25,8 @@ class FriendController(
     private val requestFriendUseCase: RequestFriendUseCase,
     private val handleFriendRequestUseCase: HandleFriendRequestUseCase,
     private val queryUserListUseCase: QueryUserListUseCase,
-    private val queryMyFriendListUseCase: QueryMyFriendListUseCase
+    private val queryMyFriendListUseCase: QueryMyFriendListUseCase,
+    private val queryMyFriendRequestListUseCase: QueryMyFriendRequestListUseCase
 ) {
 
     @ResponseStatus(HttpStatus.OK)
@@ -55,5 +58,10 @@ class FriendController(
         @RequestParam(value = "name", required = false, defaultValue = "") name: String
     ): UserListResponse {
         return queryMyFriendListUseCase.execute(page, name)
+    }
+
+    @GetMapping("/request")
+    fun getRequestFriendList(): FriendRequestListResponse {
+        return queryMyFriendRequestListUseCase.execute()
     }
 }

--- a/src/main/kotlin/dsm/wemeet/domain/friend/presentation/dto/response/FriendRequestListResponse.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/presentation/dto/response/FriendRequestListResponse.kt
@@ -1,0 +1,17 @@
+package dsm.wemeet.domain.friend.presentation.dto.response
+
+import dsm.wemeet.domain.user.repository.model.Position
+import java.util.UUID
+
+data class FriendRequestListResponse(
+    val friendRequests: List<FriendRequestResponse>,
+    val requestCnt: Int
+)
+
+data class FriendRequestResponse(
+    val friendId: UUID,
+    val accountId: String,
+    val profile: String?,
+    val aboutMe: String?,
+    val position: List<Position>
+)

--- a/src/main/kotlin/dsm/wemeet/domain/friend/repository/FriendJpaRepository.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/repository/FriendJpaRepository.kt
@@ -28,7 +28,7 @@ interface FriendJpaRepository : JpaRepository<Friend, UUID> {
         AND f.isAccepted = :isAccepted
     """
     )
-    fun findFriendsByEmailAndAcceptanceStatus(@Param("email") email: String, @Param("isAccepted") isAccepted: Boolean): List<Friend>
+    fun findFriendsByEmailAndIsAccepted(@Param("email") email: String, @Param("isAccepted") isAccepted: Boolean): List<Friend>
 
     @Query(
         """

--- a/src/main/kotlin/dsm/wemeet/domain/friend/repository/FriendJpaRepository.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/repository/FriendJpaRepository.kt
@@ -24,11 +24,11 @@ interface FriendJpaRepository : JpaRepository<Friend, UUID> {
         """
         SELECT f 
         FROM Friend f 
-        WHERE (f.proposer.email = :user OR f.receiver.email = :user)
-        AND f.isAccepted = true
+        WHERE (f.proposer.email = :email OR f.receiver.email = :email)
+        AND f.isAccepted = :isAccepted
     """
     )
-    fun findAcceptedFriendsByUser(@Param("user") user: String): List<Friend>
+    fun findFriendsByEmailAndAcceptanceStatus(@Param("email") email: String, @Param("isAccepted") isAccepted: Boolean): List<Friend>
 
     @Query(
         """

--- a/src/main/kotlin/dsm/wemeet/domain/friend/service/QueryFriendService.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/service/QueryFriendService.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 
 interface QueryFriendService {
 
-    fun queryAcceptedFriendsByUser(userId: String): List<Friend>
+    fun queryFriendsByEmailAndAcceptance(email: String, isAccepted: Boolean): List<Friend>
 
     fun queryFriendById(id: UUID): Friend
 

--- a/src/main/kotlin/dsm/wemeet/domain/friend/service/QueryFriendService.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/service/QueryFriendService.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 
 interface QueryFriendService {
 
-    fun queryFriendsByEmailAndAcceptance(email: String, isAccepted: Boolean): List<Friend>
+    fun queryFriendsByEmailAndIsAccepted(email: String, isAccepted: Boolean): List<Friend>
 
     fun queryFriendById(id: UUID): Friend
 

--- a/src/main/kotlin/dsm/wemeet/domain/friend/service/impl/QueryFriendServiceImpl.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/service/impl/QueryFriendServiceImpl.kt
@@ -16,8 +16,8 @@ class QueryFriendServiceImpl(
     private val friendJpaRepository: FriendJpaRepository
 ) : QueryFriendService {
 
-    override fun queryAcceptedFriendsByUser(userId: String): List<Friend> =
-        friendJpaRepository.findAcceptedFriendsByUser(userId)
+    override fun queryFriendsByEmailAndAcceptance(email: String, isAccepted: Boolean): List<Friend> =
+        friendJpaRepository.findFriendsByEmailAndAcceptanceStatus(email, isAccepted)
 
     override fun queryFriendById(id: UUID) =
         friendJpaRepository.findByIdOrNull(id) ?: throw FriendNotFoundException

--- a/src/main/kotlin/dsm/wemeet/domain/friend/service/impl/QueryFriendServiceImpl.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/service/impl/QueryFriendServiceImpl.kt
@@ -16,8 +16,8 @@ class QueryFriendServiceImpl(
     private val friendJpaRepository: FriendJpaRepository
 ) : QueryFriendService {
 
-    override fun queryFriendsByEmailAndAcceptance(email: String, isAccepted: Boolean): List<Friend> =
-        friendJpaRepository.findFriendsByEmailAndAcceptanceStatus(email, isAccepted)
+    override fun queryFriendsByEmailAndIsAccepted(email: String, isAccepted: Boolean): List<Friend> =
+        friendJpaRepository.findFriendsByEmailAndIsAccepted(email, isAccepted)
 
     override fun queryFriendById(id: UUID) =
         friendJpaRepository.findByIdOrNull(id) ?: throw FriendNotFoundException

--- a/src/main/kotlin/dsm/wemeet/domain/friend/usecase/QueryMyFriendRequestListUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/usecase/QueryMyFriendRequestListUseCase.kt
@@ -1,0 +1,46 @@
+package dsm.wemeet.domain.friend.usecase
+
+import dsm.wemeet.domain.friend.presentation.dto.response.FriendRequestListResponse
+import dsm.wemeet.domain.friend.presentation.dto.response.FriendRequestResponse
+import dsm.wemeet.domain.friend.repository.model.Friend
+import dsm.wemeet.domain.friend.service.QueryFriendService
+import dsm.wemeet.domain.user.repository.model.Position
+import dsm.wemeet.domain.user.repository.model.User
+import dsm.wemeet.domain.user.service.QueryUserService
+import dsm.wemeet.global.s3.S3Util
+import org.springframework.stereotype.Service
+
+@Service
+class QueryMyFriendRequestListUseCase(
+    private val queryUserService: QueryUserService,
+    private val queryFriendService: QueryFriendService,
+    private val s3Util: S3Util
+) {
+
+    fun execute(): FriendRequestListResponse {
+        val user = queryUserService.getCurrentUser()
+        val friendRequests = queryFriendService.queryFriendsByEmailAndAcceptance(user.email, false)
+        val cnt = friendRequests.size
+
+        val friendRequestsResponses = friendRequests.map {
+            val opponent = getOpponent(it, user)
+            FriendRequestResponse(
+                friendId = it.id!!,
+                accountId = opponent.accountId,
+                profile = opponent.profile?.let { s3Util.generateUrl(it) },
+                aboutMe = opponent.aboutMe,
+                position = opponent.position.split(",").map { Position.valueOf(it) }
+            )
+        }
+
+        return FriendRequestListResponse(friendRequests = friendRequestsResponses, requestCnt = cnt)
+    }
+
+    private fun getOpponent(friend: Friend, currentUser: User): User {
+        return if (friend.proposer.email == currentUser.email) {
+            friend.receiver
+        } else {
+            friend.proposer
+        }
+    }
+}

--- a/src/main/kotlin/dsm/wemeet/domain/friend/usecase/QueryMyFriendRequestListUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/friend/usecase/QueryMyFriendRequestListUseCase.kt
@@ -19,7 +19,7 @@ class QueryMyFriendRequestListUseCase(
 
     fun execute(): FriendRequestListResponse {
         val user = queryUserService.getCurrentUser()
-        val friendRequests = queryFriendService.queryFriendsByEmailAndAcceptance(user.email, false)
+        val friendRequests = queryFriendService.queryFriendsByEmailAndIsAccepted(user.email, false)
         val cnt = friendRequests.size
 
         val friendRequestsResponses = friendRequests.map {

--- a/src/main/kotlin/dsm/wemeet/domain/user/presentation/dto/response/MyPageResponse.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/user/presentation/dto/response/MyPageResponse.kt
@@ -1,13 +1,10 @@
 package dsm.wemeet.domain.user.presentation.dto.response
 
-import dsm.wemeet.domain.friend.presentation.dto.response.FriendResponse
 import dsm.wemeet.domain.user.repository.model.Position
 
 data class MyPageResponse(
     val accountId: String,
     val profile: String?,
     val aboutMe: String?,
-    val position: List<Position>,
-    val friendsCnt: Int,
-    val friends: List<FriendResponse>
+    val position: List<Position>
 )

--- a/src/main/kotlin/dsm/wemeet/domain/user/usecase/UserMyPageUseCase.kt
+++ b/src/main/kotlin/dsm/wemeet/domain/user/usecase/UserMyPageUseCase.kt
@@ -1,7 +1,5 @@
 package dsm.wemeet.domain.user.usecase
 
-import dsm.wemeet.domain.friend.presentation.dto.response.FriendResponse
-import dsm.wemeet.domain.friend.service.QueryFriendService
 import dsm.wemeet.domain.user.presentation.dto.response.MyPageResponse
 import dsm.wemeet.domain.user.repository.model.Position
 import dsm.wemeet.domain.user.service.QueryUserService
@@ -11,34 +9,18 @@ import org.springframework.stereotype.Service
 @Service
 class UserMyPageUseCase(
     private val queryUserService: QueryUserService,
-    private val queryFriendService: QueryFriendService,
     private val s3Util: S3Util
 ) {
 
     fun execute(): MyPageResponse {
         val user = queryUserService.getCurrentUser()
-        val friends = queryFriendService.queryAcceptedFriendsByUser(user.email)
         val profileUrl = user.profile?.let { s3Util.generateUrl(it) }
-
-        val friendResponses = friends.map { it ->
-            val friend = if (it.proposer == user) it.receiver else it.proposer
-            val friendProfile = friend.profile?.let { s3Util.generateUrl(it) }
-
-            FriendResponse(
-                accountId = friend.accountId,
-                profile = friendProfile,
-                aboutMe = friend.aboutMe,
-                position = friend.position.split(",").map { Position.valueOf(it) }
-            )
-        }
 
         return MyPageResponse(
             accountId = user.accountId,
             profile = profileUrl,
             aboutMe = user.aboutMe,
-            position = user.position.split(",").map { Position.valueOf(it) },
-            friendsCnt = friendResponses.size,
-            friends = friendResponses
+            position = user.position.split(",").map { Position.valueOf(it) }
         )
     }
 }

--- a/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/wemeet/global/config/security/SecurityConfig.kt
@@ -48,6 +48,7 @@ class SecurityConfig(
                 .requestMatchers(HttpMethod.PATCH, "/friends/request/{friend-id}").authenticated()
                 .requestMatchers(HttpMethod.GET, "/friends/my").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/friends/{friend-id}").authenticated()
+                .requestMatchers(HttpMethod.GET, "/friends/request").authenticated()
                 .requestMatchers(HttpMethod.POST, "/rooms").authenticated()
                 .requestMatchers(HttpMethod.POST, "/rooms/{room-id}").authenticated()
                 .requestMatchers(HttpMethod.GET, "/rooms").authenticated()

--- a/src/main/kotlin/dsm/wemeet/global/s3/S3Util.kt
+++ b/src/main/kotlin/dsm/wemeet/global/s3/S3Util.kt
@@ -28,9 +28,6 @@ class S3Util(
     @Value("\${cloud.aws.s3.bucket}")
     lateinit var bucketName: String
 
-    @Value("\${cloud.aws.s3.exp-time}")
-    lateinit var s3Exp: String
-
     fun upload(file: MultipartFile): String {
         val name = UUID.randomUUID()
         val ext = verificationFile(file)
@@ -82,8 +79,6 @@ class S3Util(
     }
 
     fun generateUrl(fileName: String): String {
-        val exp = Duration.ofSeconds(s3Exp.toLong())
-
         val imgRequest = GetObjectRequest.builder()
             .bucket(bucketName)
             .key(fileName)
@@ -91,7 +86,7 @@ class S3Util(
 
         val freshUrl = s3Presigner.presignGetObject { builder ->
             builder.getObjectRequest(imgRequest)
-                .signatureDuration(exp)
+                .signatureDuration(Duration.ofHours(1))
         }
 
         return freshUrl.url().toString()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,6 @@ cloud:
       secretKey: ${AWS_SECRET_KEY}
     s3:
       bucket: ${AWS_BUCKET}
-      exp-time: 604800000
     region:
       static: ${AWS_STATIC:ap-northeast-2}
     stack:


### PR DESCRIPTION
close #94 
<img width="578" alt="와우" src="https://github.com/user-attachments/assets/847a3545-07b9-47b4-92ed-51402e519fbf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 친구 요청 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
- **버그 수정**
    - 마이페이지 응답에서 친구 수 및 친구 목록 정보가 제거되었습니다.
- **보안**
    - 친구 요청 목록 조회 엔드포인트에 인증이 적용되었습니다.
- **환경설정**
    - S3 presigned URL의 만료 시간이 1시간으로 고정되었습니다.
    - 관련 S3 만료 시간 설정값이 환경설정에서 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->