### PR TITLE
refactor :: [#118] 커넥션 실패 메시지 수정

### DIFF
--- a/src/main/kotlin/dsm/wemeet/global/socket/domain/RoomWebSocketHandler.kt
+++ b/src/main/kotlin/dsm/wemeet/global/socket/domain/RoomWebSocketHandler.kt
@@ -48,7 +48,7 @@ class RoomWebSocketHandler(
             // 이미 세션에 들어와있는지
             peers.find { getUserEmail(it) == getUserEmail(session) }?.let { throw AlreadyJoinedRoomException }
         } catch (e: WeMeetException) {
-            session.close(CloseStatus(1008, e.message)) // POLICY_VIOLATION
+            session.close(CloseStatus(1008, "${e.errorCode.status}-${e.errorCode.message}")) // POLICY_VIOLATION
         } catch (e: Exception) {
             session.close(CloseStatus.SERVER_ERROR)
             logger.error("유효 검증 중 예기치 못한 에러 발생", e)


### PR DESCRIPTION
resolve #118
![image](https://github.com/user-attachments/assets/fbb3f425-7096-48f6-9ec5-b1165a0a1494)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - WebSocket 연결 시 발생하는 오류에 대해 더 구체적인 오류 코드와 메시지가 포함된 종료 사유를 제공하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->